### PR TITLE
Upgrade rollup, rollup plugins and react

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "name": "react-lib-template",
   "description": "React Library Template",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": "Roberto Mauro <erremauro@icloud.com>",
   "repository": "https://github.com/erremauro/react-lib-template.git",
   "main": "dist/index.js",
@@ -54,14 +54,18 @@
   },
   "peerDependencies": {
     "prop-types": "^15.7.2",
-    "react": "^16.12.0",
-    "react-dom": "^16.12.0"
+    "react": "^16.13.1",
+    "react-dom": "^16.13.1"
   },
   "devDependencies": {
     "@babel/core": "^7.7.4",
     "@babel/plugin-proposal-class-properties": "^7.7.4",
     "@babel/preset-env": "^7.7.4",
     "@babel/preset-react": "^7.7.4",
+    "@rollup/plugin-babel": "^5.1.0",
+    "@rollup/plugin-commonjs": "^14.0.0",
+    "@rollup/plugin-node-resolve": "^8.4.0",
+    "@rollup/plugin-url": "^5.0.1",
     "babel-eslint": "^10.0.3",
     "cross-env": "^7.0.2",
     "eslint": "^6.7.1",
@@ -75,16 +79,12 @@
     "fs-extra": "^9.0.0",
     "gh-pages": "^2.1.1",
     "humps": "^2.0.1",
-    "react": "^16.12.0",
-    "react-dom": "^16.12.0",
-    "react-scripts": "^3.2.0",
+    "react": "^16.13.1",
+    "react-dom": "^16.13.1",
+    "react-scripts": "^3.4.1",
     "rear-logger": "^1.0.0",
-    "rollup": "^2.6.1",
-    "rollup-plugin-babel": "^4.3.3",
-    "rollup-plugin-commonjs": "^10.1.0",
-    "rollup-plugin-node-resolve": "^5.2.0",
-    "rollup-plugin-peer-deps-external": "^2.2.0",
-    "rollup-plugin-postcss": "^2.0.3",
-    "rollup-plugin-url": "^3.0.1"
+    "rollup": "^2.23.0",
+    "rollup-plugin-peer-deps-external": "^2.2.3",
+    "rollup-plugin-postcss": "^3.1.3"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,9 +1,9 @@
-import babel from 'rollup-plugin-babel'
-import commonjs from 'rollup-plugin-commonjs'
+import babel from '@rollup/plugin-babel'
+import commonjs from '@rollup/plugin-commonjs'
 import external from 'rollup-plugin-peer-deps-external'
 import postcss from 'rollup-plugin-postcss'
-import resolve from 'rollup-plugin-node-resolve'
-import url from 'rollup-plugin-url'
+import resolve from '@rollup/plugin-node-resolve'
+import url from '@rollup/plugin-url'
 
 import pkg from './package.json'
 


### PR DESCRIPTION
Details
=======

- Upgrade react version to 16.13.1
- Upgrade rollup version to 2.23.0
- Upgrade rollup deprecated plugins
- Update `rollup.config.js` to the newest plugins